### PR TITLE
Changed link to point to the homepage listed in manifest.json

### DIFF
--- a/check_for_link.js
+++ b/check_for_link.js
@@ -23,7 +23,8 @@ function displayPopup(){
     // Create more info link
     var moreInfo = document.createElement('a');
     moreInfo.setAttribute('id', 'CCPAMoreInfo');
-    moreInfo.setAttribute('href', 'http://www.google.com/');
+    moreInfo.setAttribute('href', browser.runtime.getManifest().homepage_url);
+    moreInfo.setAttribute('target', '_blank');
     moreInfo.innerHTML = 'More Info';
     popup.appendChild(moreInfo);
 


### PR DESCRIPTION
Instead of pointing towards Google, the extension will point the "More info" link towards whatever is listed as the homepage in manifest.json