### PR TITLE
Automatically load popup.css

### DIFF
--- a/check_for_link.js
+++ b/check_for_link.js
@@ -47,13 +47,6 @@ function displayPopup() {
  * results back to background script.
  */
 
-// Add notification stylesheet
-var link = document.createElement('link');
-link.setAttribute('rel', 'stylesheet');
-link.setAttribute('type', 'text/css');
-link.setAttribute('href', browser.runtime.getURL('./popup.css'));
-document.getElementsByTagName('head')[0].appendChild(link);
-
 // Search page elements for CCPA opt-out link
 var pageElements = document.getElementsByTagName('*');
 var linkDetected = false;

--- a/manifest.json
+++ b/manifest.json
@@ -26,10 +26,10 @@
       "js": [
         "check_for_link.js",
         "click_scripts.js"
+      ],
+      "css":[
+        "popup.css"
       ]
     }
-  ],
-  "web_accessible_resources":[
-    "popup.css"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,8 @@
         "click_scripts.js"
       ]
     }
+  ],
+  "web_accessible_resources":[
+    "popup.css"
   ]
 }


### PR DESCRIPTION
Loads popup.css automatically so that it will be present.

Right now, as popup.css is not listed in the manifest's `web_accessable_resources`, will not load ([more info](https://developer.chrome.com/extensions/manifest/web_accessible_resources)). Adding this will automatically load it on any new site.

The other option would be to add popup.css to the `web_accessable_resources` part of the manifest, but this saves a bit of javascript by loading it the way that is built into the browser.